### PR TITLE
vimd2h.py: exclude "`" from PAT_WORDCHAR

### DIFF
--- a/vimd2h.py
+++ b/vimd2h.py
@@ -17,7 +17,8 @@ except:
 RE_TAGLINE = re.compile(r'(\S+)\s+(\S+)')
 RE_LINE1_HELP = re.compile(r'^\*\S+\*\s.*')
 
-PAT_WORDCHAR = '[!#-)+-{}~\xC0-\xFF]'
+# grab an ASCII table and carefully note what the embedded X-Y ranges exclude
+PAT_WORDCHAR = '[!#-)+-_a-{}~\xC0-\xFF]'
 
 PAT_HEADER   = r'(^.*~$)'
 PAT_GRAPHIC  = r'(^.* `$)'


### PR DESCRIPTION
Things like `` " (`keys` ..." `` (backquote after paren) were not recognized.

This was a nasty one to track down. The minuses in `PAT_WORDCHAR` represent ranges, and the key is to grab an ASCII table and pore over what they exclude. Before, the backtick was a wordchar.