### PR TITLE
vimd2h.py: discard duplicate unresolved warnings

### DIFF
--- a/vimd2h.py
+++ b/vimd2h.py
@@ -72,7 +72,7 @@ class Link(object):
 class VimDoc2HTML(object):
     def __init__(self, tags, version=None):
         self._urls = { }
-        self._urlsCI = { }
+        self._urlsCI = { }  # lowercased tag -> set of cased versions
         self._urlsUnresolved = set()
         self._version = version
         for line in RE_NEWLINE.split(tags):
@@ -95,7 +95,11 @@ class VimDoc2HTML(object):
             elif special is not None: classattr = ' class="s"'
         link_plain = part1 + classattr + part2
         self._urls[tag] = Link(link_pipe, link_plain)
-        self._urlsCI[tag.lower()] = True
+        lowerTag = tag.lower()
+        if lowerTag in self._urlsCI:
+            self._urlsCI[lowerTag].add(tag)
+        else:
+            self._urlsCI[lowerTag] = set((tag,))
 
     def maplink(self, tag, css_class=None):
         links = self._urls.get(tag)
@@ -109,9 +113,8 @@ class VimDoc2HTML(object):
                     lowerTag = tag.lower()
                     if lowerTag in self._urlsCI:
                         print('Unresolved reference: |%s|' % tag)
-                        for key in self._urls:
-                            if key.lower() == lowerTag:
-                                print('  - tag with different case: |%s|' % key)
+                        for okTag in self._urlsCI[lowerTag]:
+                            print('  - tag with different case: |%s|' % okTag)
                     else:
                         print('Unresolved reference: |%s|' % tag)
 

--- a/vimd2h.py
+++ b/vimd2h.py
@@ -73,6 +73,7 @@ class VimDoc2HTML(object):
     def __init__(self, tags, version=None):
         self._urls = { }
         self._urlsCI = { }
+        self._urlsUnresolved = set()
         self._version = version
         for line in RE_NEWLINE.split(tags):
             m = RE_TAGLINE.match(line)
@@ -103,14 +104,16 @@ class VimDoc2HTML(object):
             else: return links.link_plain
         elif css_class is not None:
             if css_class == 'l':
-                lowerTag = tag.lower()
-                if lowerTag in self._urlsCI:
-                    print('Unresolved reference: |%s|' % tag)
-                    for key in self._urls:
-                        if key.lower() == lowerTag:
-                            print('  - tag with different case: |%s|' % key)
-                else:
-                    print('Unresolved reference: |%s|' % tag)
+                if tag not in self._urlsUnresolved:
+                    self._urlsUnresolved.add(tag)
+                    lowerTag = tag.lower()
+                    if lowerTag in self._urlsCI:
+                        print('Unresolved reference: |%s|' % tag)
+                        for key in self._urls:
+                            if key.lower() == lowerTag:
+                                print('  - tag with different case: |%s|' % key)
+                    else:
+                        print('Unresolved reference: |%s|' % tag)
 
             return '<span class="' + css_class + '">' + html_escape[tag] + \
                     '</span>'


### PR DESCRIPTION
Otherwise output can get quite spammy for cross-doc references, masking the "real" unresolveds.